### PR TITLE
ramips: add support for Dlink DIR-878 A1

### DIFF
--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_uimage.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_uimage.c
@@ -424,6 +424,43 @@ static struct mtd_part_parser uimage_fonfxc_parser = {
 };
 
 /**************************************************
+ * ubootpad96
+ **************************************************/
+
+#define ubootpad96_PAD_LEN		96
+
+static ssize_t uimage_find_ubootpad96(u_char *buf, size_t len, int *extralen)
+{
+	if (uimage_verify_default(buf, len, extralen) < 0)
+		return -EINVAL;
+
+	*extralen = ubootpad96_PAD_LEN;
+
+	return 0;
+}
+
+static int
+mtdsplit_uimage_parse_ubootpad96(struct mtd_info *master,
+			      const struct mtd_partition **pparts,
+			      struct mtd_part_parser_data *data)
+{
+	return __mtdsplit_parse_uimage(master, pparts, data,
+				       uimage_find_ubootpad96);
+}
+
+static const struct of_device_id mtdsplit_uimage_ubootpad96_of_match_table[] = {
+	{ .compatible = "ubootpad96,uimage" },
+	{},
+};
+
+static struct mtd_part_parser uimage_ubootpad96_parser = {
+	.owner = THIS_MODULE,
+	.name = "ubootpad96-fw",
+	.of_match_table = mtdsplit_uimage_ubootpad96_of_match_table,
+	.parse_fn = mtdsplit_uimage_parse_ubootpad96,
+};
+
+/**************************************************
  * OKLI (OpenWrt Kernel Loader Image)
  **************************************************/
 
@@ -490,6 +527,7 @@ static int __init mtdsplit_uimage_init(void)
 	register_mtd_parser(&uimage_netgear_parser);
 	register_mtd_parser(&uimage_edimax_parser);
 	register_mtd_parser(&uimage_fonfxc_parser);
+	register_mtd_parser(&uimage_ubootpad96_parser);
 	register_mtd_parser(&uimage_okli_parser);
 
 	return 0;

--- a/target/linux/ramips/dts/mt7621_dlink_dir-878-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-878-a1.dts
@@ -1,0 +1,180 @@
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "dlink,dir-878-a1", "mediatek,mt7621-soc";
+	model = "D-Link DIR-878 A1";
+
+	aliases {
+		led-boot = &led_power_orange;
+		led-failsafe = &led_power_green;
+		led-running = &led_power_green;
+		led-upgrade = &led_net_orange;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_orange: power_orange {
+			label = "dir-878-a1:orange:power";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_green: power_green {
+			label = "dir-878-a1:green:power";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		led_net_orange: net_orange {
+			label = "dir-878-a1:orange:net";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		net_green {
+			label = "dir-878-a1:green:net";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		wifi {
+			label = "wifi";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x20000>;
+				read-only;
+			};
+
+			partition@60000 {
+				compatible = "ubootpad96,uimage";
+				label = "firmware";
+				reg = <0x60000 0xfa0000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+
+		led {
+			led-active-low;
+		};
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		led {
+			led-active-low;
+		};
+	};
+};
+
+&gmac0 {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+			mtd-mac-address = <&factory 0xe006>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -87,6 +87,11 @@ define Build/netis-tail
 		sed 's/../\\\\x&/g' | xargs echo -ne >> $@
 endef
 
+define Build/ubootpad96
+	uimage_padhdr -i $@ -o $@.new -l 96
+	mv $@.new $@
+endef
+
 define Build/ubnt-erx-factory-image
 	if [ -e $(KDIR)/tmp/$(KERNEL_INITRAMFS_IMAGE) -a "$$(stat -c%s $@)" -lt "$(KERNEL_SIZE)" ]; then \
 		echo '21001:6' > $(1).compat; \
@@ -227,6 +232,21 @@ define Device/dlink_dir-860l-b1
   SUPPORTED_DEVICES += dir-860l-b1
 endef
 TARGET_DEVICES += dlink_dir-860l-b1
+
+define Device/dlink_dir-878-a1
+  IMAGE_SIZE := 16000k
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := DIR-878
+  DEVICE_VARIANT := A1
+  DEVICE_PACKAGES := kmod-mt7615e wpad-basic
+  KERNEL_INITRAMFS := $$(KERNEL) | ubootpad96
+  IMAGES += factory.bin
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | ubootpad96 |\
+	pad-rootfs | check-size | append-metadata
+  IMAGE/factory.bin := append-kernel | append-rootfs | ubootpad96 |\
+  	check-size
+endef
+TARGET_DEVICES += dlink_dir-878-a1
 
 define Device/d-team_newifi-d2
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -26,7 +26,8 @@ d-team,pbr-m1|\
 gehua,ghl-r-001)
 	ucidef_set_led_netdev "internet" "internet" "$boardname:blue:internet" "wan"
 	;;
-dlink,dir-860l-b1)
+dlink,dir-860l-b1|\
+dlink,dir-878-a1)
 	ucidef_set_led_netdev "wan" "wan" "$boardname:green:net" "wan"
 	;;
 gnubee,gb-pc1|\


### PR DESCRIPTION
Specifications:
* SoC: MT7621AT
* RAM: 128MB
* Flash: 16MB NOR SPI flash
* WiFi: MT7615N (2.4GHz) and MT7615N (5Ghz)
* LAN: 5x1000M
* Firmware layout is Uboot with extra 96 bytes in header
* Base PCB is AP-MTKH7-0002
* LEDs Power Green,Power Orange,Internet Green,Internet Orange
* LEDs "2.4G" Green & "5G" Green connected directly to wifi module
* Buttons Reset,WPS,WIFI

Flash instruction:

Upload image via emergency recovery mode via Windows "not working with Linux"
Push and hold reset button (on the bottom of the device) until power led starts flashing (about 10 secs or so) while plugging in the power cable.
Give it ~30 seconds, to boot the recovery mode GUI
Connect your client computer to LAN1 of the device
Set your client IP address manually to 192.168.0.2 / 255.255.255.0.
Call the recovery page for the device at http://192.168.0.1
Use the provided emergency web GUI to upload and flash a new firmware to the device

MAC addresses:

lan      factory 0xe000 *:55 (label)
wan      factory 0xe006 *:58
2.4 GHz  factory 0x0004 *:56
5.0 GHz  factory 0x8004 *:57

Signed-off-by: Alan Luck <luckyhome2008@gmail.com>